### PR TITLE
Open docs in new tab or window

### DIFF
--- a/src/dashboard/client/services/infrabox.service.ts
+++ b/src/dashboard/client/services/infrabox.service.ts
@@ -15,6 +15,6 @@ export class InfraBoxService {
     }
 
     public openDocs() {
-        window.open(INFRABOX_DOCS_URL, "_self");
+        window.open(INFRABOX_DOCS_URL, "_blank");
     }
 }


### PR DESCRIPTION
I think it is more convenient to have the docs in a new window to enable a side-by-side comparison between the things I want to do vs the actual UI.