### PR TITLE
trigger github build only on opened, reopened, synchronized

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ certs/
 src/stats/run.sh
 src/dashboard-client/node_modules
 .infrabox*
+*.iml
+.idea

--- a/src/github/trigger/trigger.py
+++ b/src/github/trigger/trigger.py
@@ -185,7 +185,7 @@ class Trigger(object):
 
 
     def handle_pull_request(self, event):
-        if event['action'] == 'closed':
+        if event['action'] not in ['opened', 'reopened', 'synchronized']:
             return
 
         result = self.execute('''


### PR DESCRIPTION
In the current implementation a build is triggered on everything that is not a close, e.g. reviews, comments, etc.
This is not necessary as the code does not change and the build result will be the same.

With this change the build only triggers on code changes (new commits) or when a PR is opened or reopened.