### PR TITLE
Updated dev.md file to get rid of build error.

### DIFF
--- a/docs/dev.md
+++ b/docs/dev.md
@@ -14,6 +14,11 @@ pip install pipenv
 pipenv install
 ```
 
+Then install Crypto module for Python:
+```bash
+pip install pycrypto
+```
+
 To activate the environment every time you open a new shell:
 
 ```bash


### PR DESCRIPTION
Hi!

This module isn't in the **pipenv**. If you don't install it, you will get an error, trying to build images, saying that _Crypto.PublicKey_ module is missing.

Best regards,
Kirill Abramov.