### PR TITLE
Docker version

### DIFF
--- a/src/job/Dockerfile
+++ b/src/job/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:17.03.2-dind
+FROM docker:17.12.1-ce-dind
 
 RUN apk add --no-cache \
     python \

--- a/src/job/entrypoint.sh
+++ b/src/job/entrypoint.sh
@@ -8,7 +8,7 @@ if [ ! -e /var/run/docker.sock ]; then
 
     echo "Waiting for docker daemon to start up"
     # Start docker daemon
-    dockerd-entrypoint.sh --storage-driver overlay --graph /data/docker &
+    dockerd-entrypoint.sh --storage-driver overlay --data-root /data/docker &
 
     # Wait until daemon is ready
     COUNTER=0

--- a/src/job/job.py
+++ b/src/job/job.py
@@ -872,7 +872,7 @@ class RunJob(Job):
                 for name, value in self.job['build_arguments'].iteritems():
                     cmd += ['--build-arg', '%s=%s' % (name, value)]
 
-            cmd += ['--build-arg', 'INFRABOX_BUILD_NUMBER=%s' % self.build['number']]
+            cmd += ['--build-arg', 'INFRABOX_BUILD_NUMBER=%s' % self.build['build_number']]
 
             cwd = self._get_build_context_current_job()
             c.execute(cmd, cwd=cwd, show=True)

--- a/src/job/job.py
+++ b/src/job/job.py
@@ -872,6 +872,8 @@ class RunJob(Job):
                 for name, value in self.job['build_arguments'].iteritems():
                     cmd += ['--build-arg', '%s=%s' % (name, value)]
 
+            cmd += ['--build-arg', 'INFRABOX_BUILD_NUMBER=%s' % self.build['number']]
+
             cwd = self._get_build_context_current_job()
             c.execute(cmd, cwd=cwd, show=True)
             self.cache_docker_image(image_name, cache_image)


### PR DESCRIPTION
Upgrade docker version to 17.12.1-ce-dind and pass INFRABOX_BUILD_NUMBER as argument.
This allows everybody to write:

```
FROM my-image:$INFRABOX_BUILD_NUMBER 
```

and therefore reference an image which has been deployed in the same build

Fixes #283 
Fixes #291 