### PR TITLE
Make 'Report Issue' URL configurable

### DIFF
--- a/deploy/infrabox/templates/_helpers.tpl
+++ b/deploy/infrabox/templates/_helpers.tpl
@@ -217,6 +217,9 @@
 -
     name: INFRABOX_ROOT_URL
     value: {{ .Values.root_url }}
+-
+    name: INFRABOX_GENERAL_REPORT_ISSUE_URL
+    value: {{ .Values.general.report_issue_url }}
 {{ end }}
 
 {{ define "env_docker_registry" }}

--- a/deploy/install.py
+++ b/deploy/install.py
@@ -374,6 +374,7 @@ class Kubernetes(Install):
         self.set('general.worker_namespace', self.args.general_worker_namespace)
         self.set('general.system_namespace', self.args.general_system_namespace)
         self.set('general.rbac.enabled', not self.args.general_rbac_disabled)
+        self.set('general.report_issue_url', self.args.general_report_issue_url)
         self.set('root_url', self.args.root_url)
 
         self.check_file_exists(self.args.general_rsa_private_key)
@@ -483,7 +484,11 @@ class DockerCompose(Install):
 
 
     def setup_api(self):
-        self.config.append('services.api.environment', ['INFRABOX_ROOT_URL=%s' % self.args.root_url])
+        self.config.append('services.api.environment', [
+            'INFRABOX_ROOT_URL=%s' % self.args.root_url,
+            'INFRABOX_GENERAL_REPORT_ISSUE_URL=%s' % self.args.general_report_issue_url
+        ])
+
         self.config.add('services.api.image',
                         '%s/api:%s' % (self.args.docker_registry, self.args.version))
 
@@ -705,6 +710,7 @@ def main():
     parser.add_argument('--general-rsa-public-key')
     parser.add_argument('--general-rsa-private-key')
     parser.add_argument('--general-rbac-disabled', action='store_true', default=False)
+    parser.add_argument('--general-report-issue-url', default='https://github.com/InfraBox/infrabox/issues')
 
     # Database configuration
     parser.add_argument('--database',

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -71,6 +71,7 @@ def main(): # pragma: no cover
 
     get_env('INFRABOX_JOB_MAX_OUTPUT_SIZE')
     get_env('INFRABOX_JOB_SECURITY_CONTEXT_CAPABILITIES_ENABLED')
+    get_env('INFRABOX_GENERAL_REPORT_ISSUE_URL')
 
     if get_env('INFRABOX_STORAGE_GCS_ENABLED') == 'true':
         get_env('GOOGLE_APPLICATION_CREDENTIALS')

--- a/src/api/settings.py
+++ b/src/api/settings.py
@@ -18,7 +18,8 @@ class Settings(Resource):
             'INFRABOX_GERRIT_ENABLED': os.environ['INFRABOX_GERRIT_ENABLED'] == 'true',
             'INFRABOX_ACCOUNT_SIGNUP_ENABLED': os.environ['INFRABOX_ACCOUNT_SIGNUP_ENABLED'] == 'true',
             'INFRABOX_ACCOUNT_LDAP_ENABLED': os.environ['INFRABOX_ACCOUNT_LDAP_ENABLED'] == 'true',
-            'INFRABOX_ROOT_URL': os.environ['INFRABOX_ROOT_URL']
+            'INFRABOX_ROOT_URL': os.environ['INFRABOX_ROOT_URL'],
+            'INFRABOX_GENERAL_REPORT_ISSUE_URL': os.environ['INFRABOX_GENERAL_REPORT_ISSUE_URL']
         }
 
         if github_enabled:

--- a/src/dashboard-client/src/App.vue
+++ b/src/dashboard-client/src/App.vue
@@ -71,7 +71,7 @@
                 </md-list-item>
 
                 <md-list-item class="navi-link">
-                    <a href="https://github.com/InfraBox/infrabox/issues"
+                    <a :href="$store.state.settings.INFRABOX_GENERAL_REPORT_ISSUE_URL"
                        class="md-list-item-container md-button"
                        target="_blank" @click="toggleLeftSidenav()">
                         <md-icon><i class="fa fa-bug fa-fw"></i></md-icon>


### PR DESCRIPTION
You can now specify the link of 'Report Issue' with the install.py
option `--general-report-issue-url`.

Fixes #317